### PR TITLE
update site to latest shotover docs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,12 +5,15 @@ set -u
 
 rm -rf docs/docs/examples
 rm -rf docs/docs/user-guide
-git clone https://github.com/shotover/shotover-proxy.git --depth 1
+# TODO: in the future pin to a specific release, the docs for the latest release 0.4.1 is broken so we cant do that yet.
+#git clone --depth 1 --branch v0.4.1 https://github.com/shotover/shotover-proxy.git
+git clone --depth 1 https://github.com/shotover/shotover-proxy.git
 rm -rf docs/docs/latest
 mv shotover-proxy/docs/src docs/docs/latest
 rm -rf shotover-proxy
 cd docs/docs/latest
 find . -type f -name "*.md" -exec sed -i 's/```YAML/```yaml/g' {} +
+find . -type f -name "*.md" -exec sed -i 's/```plain/```/g' {} +
 find . -type f -name "*.md" -exec sed -i 's/```console/```make/g' {} +
 rm logo.png logo.svg index.md SUMMARY.md
 cd ../../../

--- a/docs/docs/config.js
+++ b/docs/docs/config.js
@@ -11,7 +11,7 @@ export default [
   },
   {
     items: [
-      { text: 'Source Types', link: '/docs/latest/source-types' }
+      { text: 'Source Types', link: '/docs/latest/sources.md' }
     ]
   },
   {
@@ -39,7 +39,7 @@ export default [
   },
   {
     items: [
-      { text: 'Contributing', link: '/docs/latest/contributing' }
+      { text: 'Contributing', link: '/docs/latest/dev-docs/contributing' }
     ]
   }
 ]


### PR DESCRIPTION
Pull in changes to docs since the website was last updated.
Rather than using the latest master we use `--branch` to specify a certain tag, this way we can avoid pulling in unpublished changes from the latest master.
However [0.4.1 is actually broken](https://github.com/shotover/shotover-proxy/pull/1747) so for now we just comment it out and use the latest main branch.

The additional sed line is adding another case to a super hacky workaround for the fact that we are using an old alpha release of this web framework that blows up when we use certain markdown codeblock language names and upgrading the framework is non-trivial.
In this case its blowing up because of this line specifically: https://github.com/shotover/shotover-proxy/blob/e94328d979121f00a336820af1cfeaa65d3e34b2/docs/src/dev-docs/debugging.md?plain=1#L41

I think merging this PR should publish the changes to the site.

